### PR TITLE
Use mermaid git graphs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -56,7 +56,8 @@ weight = 40
   disableBreadcrumb = false
   disableNextPrev = false
   themeVariant = "rse-learn"
-
+  disableMermaid = false
+  customMermaidURL = "https://unpkg.com/mermaid@9.1.7/dist/mermaid.min.js"
 
 
 [markup]

--- a/content/04-collaborative_github_advanced/00-intro.md
+++ b/content/04-collaborative_github_advanced/00-intro.md
@@ -28,3 +28,19 @@ Branching is a core concept in Git. There's only one rule: **anything in the `ma
 
 
 it's extremely important that your new branch is created off of main when working on a feature or a fix. Your branch name should be descriptive, so that others can see what is being worked on.
+
+
+{{<mermaid>}}
+%%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'showBranches': true,'showCommitLabel': false}} }%%
+gitGraph
+    commit
+    commit
+    commit
+    commit
+    commit
+    branch feature
+    checkout feature
+    commit
+    commit
+    checkout main
+{{</mermaid>}}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/annakrystalli/rse-workshop-materials-template
 go 1.14
 
 require (
-	github.com/dzello/reveal-hugo v0.0.0-20210413081415-39511a646b9c // indirect
-	github.com/matcornic/hugo-theme-learn v0.0.0-20210331234833-d198cbe65f06 // indirect
+	github.com/dzello/reveal-hugo v0.0.0-20220710134748-1c7822db0cf2 // indirect
+	github.com/matcornic/hugo-theme-learn v0.0.0-20211028190410-e817f53d690d // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,11 @@ github.com/dzello/reveal-hugo v0.0.0-20200513004858-ff9f389743ae h1:x2cMxkgkOshG
 github.com/dzello/reveal-hugo v0.0.0-20200513004858-ff9f389743ae/go.mod h1:0S5eDEdHBx8tSj8veo9lUnuJRXa8WqmpANd0Lz7CLc8=
 github.com/dzello/reveal-hugo v0.0.0-20210413081415-39511a646b9c h1:MqLk4B4fKbRMECHQAMY0S5RFovEtjXS9TTMLsB/NWJU=
 github.com/dzello/reveal-hugo v0.0.0-20210413081415-39511a646b9c/go.mod h1:0S5eDEdHBx8tSj8veo9lUnuJRXa8WqmpANd0Lz7CLc8=
+github.com/dzello/reveal-hugo v0.0.0-20220710134748-1c7822db0cf2 h1:8HLH/Bt9+oK+/hu/HxPUlyMbo3WUUxrDkM2aw7IzBXg=
+github.com/dzello/reveal-hugo v0.0.0-20220710134748-1c7822db0cf2/go.mod h1:0S5eDEdHBx8tSj8veo9lUnuJRXa8WqmpANd0Lz7CLc8=
 github.com/matcornic/hugo-theme-learn v0.0.0-20200911135725-023fe7ef2b4c h1:wuILQJPvX0BYvxuvktvToxtOxAcELdnPS0ppKJ4f9Dw=
 github.com/matcornic/hugo-theme-learn v0.0.0-20200911135725-023fe7ef2b4c/go.mod h1:YoToDcvQxmAFhpEuapKUysBDEBckqDEssqTrmeZ2+uY=
 github.com/matcornic/hugo-theme-learn v0.0.0-20210331234833-d198cbe65f06 h1:Vxgl1/dyKpZDstVWmxNL9BauEGxLXrcbe1T09/dEzTY=
 github.com/matcornic/hugo-theme-learn v0.0.0-20210331234833-d198cbe65f06/go.mod h1:YoToDcvQxmAFhpEuapKUysBDEBckqDEssqTrmeZ2+uY=
+github.com/matcornic/hugo-theme-learn v0.0.0-20211028190410-e817f53d690d h1:p7ktiW/GnHccjB9oO5YGY7us5v/oHmkyF0C7EDZFM3s=
+github.com/matcornic/hugo-theme-learn v0.0.0-20211028190410-e817f53d690d/go.mod h1:YoToDcvQxmAFhpEuapKUysBDEBckqDEssqTrmeZ2+uY=


### PR DESCRIPTION
Just a draft example at present to show using mermaid's git graphs in the materials.

I've had to use the `customMermaidURL` parameter of the learn theme since it hasn't been updated in a while and is quite outdated *vis a vis* mermaid. However, it would be nice to remove this at some point so we don't have to keep track of the versions.

```
{{<mermaid>}}
%%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'showBranches': true,'showCommitLabel': false}} }%%
gitGraph
    commit
    commit
    commit
    commit
    commit
    branch feature
    checkout feature
    commit
    commit
    checkout main
{{</mermaid>}}
```

Creates a git graph that looks like this at present.
![image](https://user-images.githubusercontent.com/24752124/193855052-96a28c6f-b5c8-4058-9546-8d441238fce3.png)
with the commit labels deliberately removed in this example.
