### PR TITLE
Add a recap and shortcode for including md files

### DIFF
--- a/content/04-collaborative_github_advanced/optional-recap.md
+++ b/content/04-collaborative_github_advanced/optional-recap.md
@@ -1,0 +1,9 @@
++++
+title = "(Optional) Recap"
+date =  2022-10-31T11:31:00+01:00
+weight = 1
++++
+
+{{% include "/01-getting-started-with-git-and-github/00-typical-workflow.en.md" %}}
+
+{{% include "/03-collaborative_github_basics/01-collaborating-intro.en.md" %}}

--- a/layouts/shortcodes/include.html
+++ b/layouts/shortcodes/include.html
@@ -1,0 +1,2 @@
+{{$file := .Get 0}}
+{{ with .Site.GetPage "page" $file }}{{ .Content | markdownify }}{{ end }}


### PR DESCRIPTION
This PR adds a shortcode `layouts/shortcodes/include.html` which allows us to include other pages.

This is motivated by the desire to have some recap materials, but I wanted to avoid repetition (like a good little software engineer).

Interested to know whether people think this is a good approach or whether we'd just prefer something simpler.

Resolves #52 