### PR TITLE
fixed connecting kraken to github 404 on setup page

### DIFF
--- a/content/setup/gitkraken/_index.en.html
+++ b/content/setup/gitkraken/_index.en.html
@@ -31,7 +31,7 @@ authenticate with GitHub</strong>. You can then use GitKraken Client to
 key</a></strong> that authenticates git operations on GitHub through
 GitKraken Client. Follow <a href="https://help.gitkraken.com/gitkraken-client/github-gitkraken-client/">the
 instructions on the GitKraken site</a> to perform both steps.</p>
-<iframe src="https://help.gitkraken.com/gitkraken-client/github-gitkraken-client/" width="672" height="400px" data-external="1">
+<iframe src="https://help.gitkraken.com/gitkraken-desktop/github-gitkraken-desktop/" width="672" height="400px" data-external="1">
 </iframe>
 </div>
 <div id="turn-off-gpg" class="section level3">


### PR DESCRIPTION
Looks like they changed the URL of the connecting to github account page on the gitkraken website, so there was a 404 error. I have updated it to the new URL.