### PR TITLE
Add GitHub Actions workflow for compiling the site

### DIFF
--- a/.github/workflows/build-hugo.yml
+++ b/.github/workflows/build-hugo.yml
@@ -11,15 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Golang compiler
-        uses: actions/setup-go@v6
-        with:
-          go-version: 1.12
-
       - name: Set up Hugo
-        shell: bash
-        run: |
-          CGO_ENABLED=1 go install -tags extended github.com/gohugoio/hugo@v0.73.0
+        uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f  # v3, pinned for security
+        with:
+          hugo-version: '0.73.0'
+          extended: true
 
       - name: Build site with Hugo
         run: |

--- a/.github/workflows/build-hugo.yml
+++ b/.github/workflows/build-hugo.yml
@@ -1,0 +1,32 @@
+name: Build site with Hugo
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Golang compiler
+        uses: actions/setup-go@v6
+        with:
+          go-version: 1.12
+
+      - name: Set up Hugo
+        shell: bash
+        run: |
+          CGO_ENABLED=1 go install -tags extended github.com/gohugoio/hugo@v0.73.0
+
+      - name: Build site with Hugo
+        run: |
+          hugo --minify
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: hugo-public
+          path: public/*


### PR DESCRIPTION
# Rationale
The current latest version of Hugo (v0.160.1) cannot build the site as it is currently due to incompatibilities introduced with new version updates (such as `.Site.IsMultiLingual` being [deprecated](https://discourse.gohugo.io/t/error-deprecated-site-ismultilingual-was-deprecated-in-hugo-v0-124-0/52025) and changed to [`hugo.isMultilingual`](https://gohugo.io/functions/hugo/ismultilingual/)).

In addition, the underlying theme used by the site, [hugo-theme-learn](https://github.com/matcornic/hugo-theme-learn), is deprecated and unmaintained (as written in their README). This means updating the site to function with the new Hugo would require a theme change, since incompatible code lives within the dependency as well.

I plan to address this by updating various things in a separate PR, but in order to ensure the changes don't break the functionality or vastly change the design of the site, I needed a way to obtain a local build of the site on its old version for comparison, and I figured that the best way to go about this would be to add a GitHub Actions workflow. This way, other people can also download the build, and in the version-upgrading PR I can update the workflow to use the new version as well.

You can see the run produced by this workflow [here](https://github.com/tstolarski/git-github-zero-to-hero/actions/runs/24993471785), and the built version of the site is available as the `hugo-public` artifact on that page.